### PR TITLE
Get python version if no .python-version file.

### DIFF
--- a/build-requirements.sh
+++ b/build-requirements.sh
@@ -8,20 +8,20 @@
 
 # Get Airflow version from Pipfile
 AIRFLOW_VERSION=$(pipenv run pip freeze | grep 'apache-airflow==' | cut -d'=' -f3)
-
 if [ "$AIRFLOW_VERSION" = "" ]; then
   AIRFLOW_VERSION=$(grep 'apache-airflow\s*= "==' Pipfile | cut -d' ' -f 3 | sed 's/"==\(.*\)"$/\1/')
 fi
-
 echo "Airflow version: $AIRFLOW_VERSION"
 
 # Get Python version from .python-version (first two parts)
 PYTHON_VERSION=$(cut -d'.' -f1-2 .python-version)
+if [ "$PYTHON_VERSION" = "" ]; then
+  PYTHON_VERSION=$(pipenv run python --version | cut -d' ' -f 2)
+fi
 echo "Python version: $PYTHON_VERSION"
 
 # Download the Airflow constraints file
 curl -O https://raw.githubusercontent.com/apache/airflow/constraints-$AIRFLOW_VERSION/constraints-$PYTHON_VERSION.txt
-
 
 # Generate the list of packages from the Pipfile
 packages=$(grep '\w\s*=\s*"==' Pipfile | cut -d= -f1 | sed 's/[[:space:]]*$/==/')

--- a/compare_dependencies.sh
+++ b/compare_dependencies.sh
@@ -5,14 +5,16 @@
 
 # Get Airflow version from Pipfile
 AIRFLOW_VERSION=$(pipenv run pip freeze | grep 'apache-airflow==' | cut -d'=' -f3)
-echo "Airflow version: $AIRFLOW_VERSION"
-
 if [ "$AIRFLOW_VERSION" = "" ]; then
   AIRFLOW_VERSION=$(grep 'apache-airflow\s*= "==' Pipfile | cut -d' ' -f 3 | sed 's/"==\(.*\)"$/\1/')
 fi
+echo "Airflow version: $AIRFLOW_VERSION"
 
 # Get Python version from .python-version (first two parts)
 PYTHON_VERSION=$(cut -d'.' -f1-2 .python-version)
+if [ "$PYTHON_VERSION" = "" ]; then
+  PYTHON_VERSION=$(pipenv run python --version | cut -d' ' -f 2)
+fi
 echo "Python version: $PYTHON_VERSION"
 
 # Download the Airflow constraints file


### PR DESCRIPTION
This change is required  because tulflow does not have a .python-version file.

Therefore, the constraints are not being applied when testing in CI/CD.